### PR TITLE
Add OGC API records dataset batch export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@ cache
 
 ## Data files
 *.avi
+*.log
 *.csv
 *.json
 *.geojson
 
-## Local config giles
+## Local config files
 ingestion.config

--- a/README.md
+++ b/README.md
@@ -19,3 +19,39 @@ More information about sample data sharing can be found in the [eMOTIONAL Cities
 5. Make sure correct environment is selected in the notebook
 
 The current notebook requires Python 3.9+ to run successfully. The file `environment.yml` contains the list of minimal package dependencies required.
+
+## How to export a dataset to OGC API records
+
+Before trying to export datasets, make sure you can run the notebooks on an example dataset to validate all dependencies and required environment configuration is valid.
+
+1. Open a python activated command line in the folder `src/ingestion`.
+2. Run the `export.py` module:
+
+```
+python -m export <DATA_ROOT_PATH> --contacts contacts.json
+```
+
+The `contacts.json` file provides metadata about institutional contacts that should be attached to the data export. An example file is provided below:
+
+```json
+{
+    "contacts": [
+        {
+            "name": "FirstName LastName",
+            "institution": "Contoso",
+            "email": "name1@example.com"
+        },
+        {
+            "name": "AnotherName AnotherLast",
+            "institution": "Contoso",
+            "email": "name2@example.com"
+        }
+    ]
+}
+```
+
+> [!NOTE]
+> If your dataset contains missing UBX synchronization signals you can provide fallback schemas to be used in case of failure, e.g.
+> ```
+> python -m export <DATA_ROOT_PATH> --contacts contacts.json --schema outdoor missing_sync
+> ```

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - pip:
     - ipyfilechooser
     - opencv-python
-    - git+https://github.com/emotional-cities/pluma-analysis.git@46cffe14b514d64a83483dbd07c93872ddc9577e
+    - git+https://github.com/emotional-cities/pluma-analysis.git@500fee94ec99103c1a72cd9bfb2556b639b4319b

--- a/src/ingestion/export.py
+++ b/src/ingestion/export.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+import logging
+from modules import *
+from pluma.schema.outdoor import build_schema as schema_outdoor
+from missing_sync import build_schema as schema_missing_sync
+
+supported_schemas = {
+    "outdoor": schema_outdoor,
+    "missing_sync": schema_missing_sync
+}
+
+def to_ogcapi_records(dataset, geodata, city: str, region: str, id: str, contacts: list[Contact] = None):
+    return DatasetRecord(dataset, geodata, properties=RecordProperties(
+        title=f'{city} Outdoor Walk: {region} Subject {id}',
+        description='Outdoor walk data collection',
+        license='CC BY-NC 4.0',
+        tool='Bonsai',
+        keywords=[f'{city}', 'Outdoor', 'Walk', 'Microclimate', 'Biosignals'],
+        contacts=contacts or [],
+        themes=[]
+    ))
+
+def read_contacts(path):
+    contacts = []
+    with open(path, encoding="utf8") as fc:
+        json_contents = json.load(fc)
+        for contact_data in json_contents["contacts"]:
+            contacts.append(Contact(
+                name=contact_data["name"],
+                institution=contact_data["institution"],
+                email=contact_data["email"]
+            ))
+    return contacts
+
+if __name__ == "__main__":
+    logging.basicConfig(filename="export.log",
+                        filemode="a",
+                        format='%(asctime)s %(name)s %(levelname)s %(message)s',
+                        datefmt='%H:%M:%S',
+                        level=logging.DEBUG)
+    parser = argparse.ArgumentParser(description="Exporter of standardized outdoor walks to OGC API records and GeoJSON datasets.")
+    parser.add_argument('root', type=str, help="The path to the root folder containing datasets.")
+    parser.add_argument('--contacts', type=str, help="The path to the JSON file specifying the list of contacts to include in the dataset.")
+    parser.add_argument('--schema', nargs='*', type=str, help=
+                        "Priority list of schemas to use for loading each dataset. If a dataset fails to load with the first schema," +
+                        "a new attempt is made with the following schema, etc, until the end of the list of schemas.")
+    args = parser.parse_args()
+    contacts = None
+    if args.contacts is not None:
+        try:
+            contacts = read_contacts(args.contacts)
+        except:
+            print(f"Error parsing contacts file: {args.contacts}")
+            raise
+
+    schemas = [(name, supported_schemas[name]) for name in args.schema or ["outdoor"]]
+
+    root = Path(args.root)
+    for match in root.glob("**/Streams_32"):
+        for (schema_name, schema) in schemas:
+            try:
+                path = match.parent
+                path_attributes = path.name.split('_')
+                city = path_attributes[0]
+                region = path_attributes[1]
+                subject_id = path_attributes[2].split('-')[-1]
+
+                print(f"Loading dataset: {path.parent.name}/{path.name}..." )
+                dataset = load_dataset(path, ubx=True, unity=False, calibrate_ubx_to_harp=schema_name != "missing_sync", schema=schema)
+                print(f"Dataset: {dataset} loaded successfully, and {'not' if not dataset.has_calibration else 'sucessfully'} calibrated.")
+                geodata = dataset.to_geoframe()
+
+                record = to_ogcapi_records(dataset, geodata, city, region, subject_id, contacts=contacts)
+                rpath = Path(record.id)
+                export_geoframe_to_geojson(geodata, rpath.with_suffix('.geojson'))
+                with open(rpath.with_suffix('.json'), 'w', encoding="utf8") as f:
+                    f.write(record.to_json())
+            except Exception as error:
+                error_msg = f"Error exporting dataset: {path} with schema {schema_name}"
+                print(error_msg)
+                logging.exception(error_msg)
+                continue
+    

--- a/src/ingestion/helpers.py
+++ b/src/ingestion/helpers.py
@@ -15,8 +15,8 @@ import cv2 as cv
 def load_dataset(root, schema, reload=True, ubx=True, unity=False, calibrate_ubx_to_harp=True, export_path=None):
     # Path to the dataset. Can be local or remote.
     dataset = Dataset(
-        root=root,
-        datasetlabel="FMUL_" + root.split("\\")[-1],
+        root=str(root),
+        datasetlabel=root.name,
         georeference= Georeference(),
         schema=schema)  # Create a Dataset object that will contain the ingested data.
     dataset.populate_streams(autoload=False)  # Add the "schema" that we want to load to our Dataset. If we want to load the whole dataset automatically, set autoload to True.

--- a/src/ingestion/modules.py
+++ b/src/ingestion/modules.py
@@ -42,8 +42,9 @@ def create_datapicker(path=None, show_summary=True, ubx=True, unity=False, calib
     def dataset_changed(chooser):
         clear_output(wait=False)
         display(chooser)
-        print(f"Loading dataset: {Path(chooser.selected_path).name}..." )
-        dataset = load_dataset(chooser.selected_path, ubx=ubx, unity=unity, calibrate_ubx_to_harp=calibrate_ubx_to_harp, schema=schema)
+        selected_path = Path(chooser.selected_path)
+        print(f"Loading dataset: {selected_path.name}..." )
+        dataset = load_dataset(selected_path, ubx=ubx, unity=unity, calibrate_ubx_to_harp=calibrate_ubx_to_harp, schema=schema)
         print(f"Dataset: {dataset} loaded successfully, and {'not' if not dataset.has_calibration else 'sucessfully'} calibrated.")
         chooser.dataset = dataset
         if show_summary:


### PR DESCRIPTION
To accelerate bulk export of all datasets to OGC API records, we provide a command line callable script that traverses a root data path, and loads and exports all encountered datasets into `.geojson` and `.json` file pairs.

Instructions were added to the `README.md` file.