### PR TITLE
Upgrade to latest ingestion streams and schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ dependencies = [
     "ipykernel>=6.29.5",
     "ipympl>=0.9.6",
     "opencv-python>=4.11.0.86",
-    "pluma-analysis>=0.9.2",
+    "pluma-analysis>=0.10.0",
 ]

--- a/src/ingestion/missing_sync.py
+++ b/src/ingestion/missing_sync.py
@@ -8,7 +8,7 @@ from pluma.stream.empatica import EmpaticaStream
 from pluma.stream.ubx import UbxStream, _UBX_MSGIDS
 from pluma.stream.microphone import MicrophoneStream
 from pluma.stream.eeg import EegStream
-from pluma.stream.zeromq import PupilGazeStream, PupilWorldCameraStream
+from pluma.stream.pupil import PupilGazeStream, PupilWorldCameraStream
 
 from pluma.io.path_helper import ComplexPath, ensure_complexpath
 


### PR DESCRIPTION
All ZMQ streams now use hardware deltas to avoid burst behavior as described in https://github.com/emotional-cities/pluma-analysis/pull/91.